### PR TITLE
extv234 support newer software version

### DIFF
--- a/ext234vfat/sbin/blkid
+++ b/ext234vfat/sbin/blkid
@@ -1,3 +1,3 @@
 #!/bin/busybox sh
 
-busybox blkid  | sed 's/\(.*KOBOeReader.*TYPE="\)ext4/\1vfat/'
+busybox blkid  | sed 's/\(.*KOBOeReader.*TYPE="\)ext./\1vfat/'

--- a/ext234vfat/sbin/blkid
+++ b/ext234vfat/sbin/blkid
@@ -1,0 +1,3 @@
+#!/bin/busybox sh
+
+busybox blkid  | sed 's/\(.*KOBOeReader.*TYPE="\)ext4/\1vfat/'

--- a/ext234vfat/sbin/blkid
+++ b/ext234vfat/sbin/blkid
@@ -1,3 +1,3 @@
 #!/bin/busybox sh
 
-busybox blkid  | sed 's/\(.*KOBOeReader.*TYPE="\)ext./\1vfat/'
+busybox blkid "$@" | sed 's/\(.*KOBOeReader.*TYPE="\)ext./\1vfat/'


### PR DESCRIPTION
Newer versions of the software on the kobo uses blkid (provided by
busybox) to check whether the partition to export through usb is vfat.
This patch overshadows the systems blkid with a version which cheekily
lies about any extX-partition named "KOBOeReader" and tells the system
it is vfat and should therefore be umounted. YMMV. Fixes #3 