### PR TITLE
Support for Kobo Sage

### DIFF
--- a/AutoShelf/etc/udev/rules.d/autoshelf.rules
+++ b/AutoShelf/etc/udev/rules.d/autoshelf.rules
@@ -1,1 +1,2 @@
 SUBSYSTEM=="module", DEVPATH=="/module/g_file_storage", RUN+="/usr/local/AutoShelf/autoshelf.sh"
+SUBSYSTEM=="module", DEVPATH=="/module/g_mass_storage", RUN+="/usr/local/AutoShelf/autoshelf.sh"


### PR DESCRIPTION
  Hi,

As discussed in the mobileread thread, here are the changes required for AutoShelf to work on Kobo Sage (with an up-to-date fbink binary).

Regards,
  Vincent
